### PR TITLE
Adds Twilio sid property to Message response

### DIFF
--- a/lib/apus/adapters/twilio_adapter.ex
+++ b/lib/apus/adapters/twilio_adapter.ex
@@ -44,8 +44,11 @@ defmodule Apus.TwilioAdapter do
     |> Map.to_list()
   end
 
+  @post_keys [:from, :to, :body, :messaging_service_sid]
+
   defp to_query_string(list) do
     list
+    |> Enum.filter(fn {key, _} -> key in @post_keys end)
     |> Enum.flat_map(fn {key, value} -> [{camelize(key), value}] end)
     |> URI.encode_query()
   end

--- a/lib/apus/message.ex
+++ b/lib/apus/message.ex
@@ -2,7 +2,7 @@ defmodule Apus.Message do
   @moduledoc """
   """
 
-  defstruct from: nil, to: nil, body: nil
+  defstruct sid: nil, from: nil, to: nil, body: nil
 
   def new(attrs \\ []), do: struct(__MODULE__, attrs)
 end

--- a/test/lib/apus/adapters/twilio_adapter_test.exs
+++ b/test/lib/apus/adapters/twilio_adapter_test.exs
@@ -47,6 +47,7 @@ defmodule Apus.TwilioAdapterTest do
       use_cassette "twilio_sms_mssid_success", match_requests_on: [:request_body] do
         {:ok, %{} = tw_message} = TwilioAdapter.deliver(message, config)
 
+        assert tw_message.sid == "resource-id"
         assert tw_message.from == nil
         assert tw_message.to == "+15557654321"
         assert tw_message.body == "Hello there"


### PR DESCRIPTION
This is needed in order to store a reference to the Twilio message