### PR TITLE
Update validation to support Twilio content templates

### DIFF
--- a/lib/apus/sms_sender.ex
+++ b/lib/apus/sms_sender.ex
@@ -69,8 +69,18 @@ defmodule Apus.SmsSender do
   end
 
   defp message_valid?(%{to: to}) when to in [nil, ""], do: {false, :to}
-  defp message_valid?(%{body: body}) when body in [nil, ""], do: {false, :body}
-  defp message_valid?(_), do: true
+
+  defp message_valid?(%{body: body, content_sid: sid}) do
+    cond do
+      is_nil_or_empty(body) and not is_nil_or_empty(sid) -> true
+      not is_nil_or_empty(body) and is_nil_or_empty(sid) -> true
+      true -> {false, :body}
+    end
+  end
+
+  defp is_nil_or_empty(value) do
+    value in [nil, ""]
+  end
 
   defp log_sent(message, adapter) do
     Logger.debug("""

--- a/test/lib/sms_sender_test.exs
+++ b/test/lib/sms_sender_test.exs
@@ -44,6 +44,16 @@ defmodule Apus.SmsSenderTest do
         body: "Hello there"
       }
 
+      assert ^message = TestSender.deliver_now(message)
+    end
+
+    test "deliver_now/1 should deliver the message using a content_sid" do
+      message = %Apus.Message{
+        from: "+15551234567",
+        to: "+15557654321",
+        content_sid: "fake-id"
+      }
+
       TestSender.deliver_now(message)
 
       assert_receive {:ok, ^message}


### PR DESCRIPTION
### Related Linear Issues
- [SEA-677](https://linear.app/seated/issue/SEA-677/fix-apus-validation-for-twilio-whatsapp)
