### PR TITLE
Update test adapter to mimic Twilio adapter

### DIFF
--- a/lib/apus/adapters/test_adapter.ex
+++ b/lib/apus/adapters/test_adapter.ex
@@ -16,9 +16,21 @@ defmodule Apus.TestAdapter do
 
   def deliver(message, _config) do
     sent_message = Map.put(message, :message_id, "SM123")
+
     send(self(), {:delivered_message, sent_message})
+
+    sent_message = update_body(sent_message)
     {:ok, sent_message}
   end
+
+  # Mimic the behavior of the Twilio adapter when the body is not present and
+  # content_variables are used. If the body is not present, Apus returns an empty string.
+  defp update_body(%{body: nil, content_variables: content_variables} = message)
+       when is_map(content_variables) do
+    Map.put(message, :body, "")
+  end
+
+  defp update_body(message), do: message
 
   def handle_config(config) do
     case Map.get(config, :deliver_later_strategy) do

--- a/lib/apus/adapters/twilio_adapter.ex
+++ b/lib/apus/adapters/twilio_adapter.ex
@@ -107,7 +107,8 @@ defmodule Apus.TwilioAdapter do
     Map.drop(message, [:content_variables])
   end
 
-  defp maybe_remove_content_variables(%{content_variables: _content_variables} = message), do: message
+  defp maybe_remove_content_variables(%{content_variables: _content_variables} = message),
+    do: message
 
   defp options(config) do
     config[:request_options] || []

--- a/lib/apus/message.ex
+++ b/lib/apus/message.ex
@@ -2,7 +2,15 @@ defmodule Apus.Message do
   @moduledoc """
   """
 
-  defstruct from: nil, to: nil, body: nil, provider: nil, message_id: nil, status_callback: nil, content_sid: nil, content_variables: nil, tags: nil
+  defstruct from: nil,
+            to: nil,
+            body: nil,
+            provider: nil,
+            message_id: nil,
+            status_callback: nil,
+            content_sid: nil,
+            content_variables: nil,
+            tags: nil
 
   def new(attrs \\ []), do: struct(__MODULE__, attrs)
 end

--- a/test/lib/apus/adapters/test_adapter_test.exs
+++ b/test/lib/apus/adapters/test_adapter_test.exs
@@ -31,6 +31,22 @@ defmodule Apus.TestAdapterTest do
       assert result == {:error, "invalid number"}
       refute_receive {:delivered_message, ^message}, 20
     end
+
+    test "deliver/2 should return an empty string for the body when it's not present" do
+      message =
+        Message.new(
+          to: "whatsapp:+15551234567",
+          content_sid: "test-sid",
+          content_variables: %{test: "Variable"},
+          message_id: "SM123"
+        )
+
+      {:ok, sent_message} = TestAdapter.deliver(message, %{})
+
+      assert_received {:delivered_message, ^message}
+      assert sent_message.message_id == "SM123"
+      assert sent_message.body == ""
+    end
   end
 
   describe "adapter config" do

--- a/test/lib/message_test.exs
+++ b/test/lib/message_test.exs
@@ -59,7 +59,7 @@ defmodule Apus.MessageTest do
                body: "Hello there",
                provider: nil,
                message_id: nil,
-               tags: %{tag1: "value1", tag2: "value2"},
+               tags: %{tag1: "value1", tag2: "value2"}
              }
     end
   end


### PR DESCRIPTION
When using the Twilio adapter with content variables, Apus returns an empty string for the body. We need the test adapter to mimic this behavior so that testing can be more accurate.

---

### Related Linear Issues
- [SEA-558](https://linear.app/seated/issue/SEA-558/fix-missing-message-text-with-whatsapp-messages)
